### PR TITLE
Show full date on rollover

### DIFF
--- a/saic/paste/templates/paste_view.html
+++ b/saic/paste/templates/paste_view.html
@@ -30,7 +30,7 @@
           Anonymous
         {% endif %}
       </span> 
-      <span class='date'>{{ commit.created|elapsed }}</span> </li>
+      <span class='date' title="{{ commit_current.created }}">{{ commit_current.created|elapsed }}</span> </li>
     {% endfor %}
   </ul>
   {% if user.is_authenticated %}


### PR DESCRIPTION
Reveals the actual post date on rollover.

Also, there should probably be an option somewhere for people to set their timezone (instead of it being site-wide.)
