### PR TITLE
removed `psycopg2==2.4.4` from requirements.txt because it's not 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ async==0.6.1
 gitdb==0.5.4
 smmap==0.8.1
 wsgiref==0.1.2
-psycopg2==2.4.4
 Whoosh==2.3.2
 django-haystack==1.2.6
 repoze.timeago==0.5


### PR DESCRIPTION
pip was failling on on the `psycopg2==2.4.4` requirement because I don't have postgres on system and the django settings.py file is configured to use sqlite3 anyways.
