### PR TITLE
Always use --color=never with git-diff

### DIFF
--- a/saic/paste/views.py
+++ b/saic/paste/views.py
@@ -66,7 +66,8 @@ def _git_diff(git_commit_object, repo):
         diff = highlight(
                 repo.git.diff(
                     transversed_commit.hexsha,
-                    git_commit_object.hexsha),
+                    git_commit_object.hexsha,
+                    color='never'),
                 DiffLexer(),
                 HtmlFormatter(
                     style='friendly',


### PR DESCRIPTION
It is possible to configured git to always execute git-diff with colorization and since the diff is rendered by letting Pygments highlight the output of git-diff, the colorizing characters, meant for the output on a tty, are included in the result.
(Use somthing like `git config --global color.diff always` , see [the git book](http://git-scm.com/book/en/Customizing-Git-Git-Configuration/) for a better explanation)
This leads to something like the following:

```
[1mdiff --git a/sqp.json b/sqp.json[m
[1mindex 593d8c1..7d45b9f 100644[m
[1m--- a/sqp.json[m
[1m+++ b/sqp.json[m
[36m@@ -1,6 +1,6 @@[m
 {[m
```

The pull request enforces git to never use its own colorization.
