### PR TITLE
Allow embedded views to render; Fix TemplateDoesNotExist exception

### DIFF
--- a/saic/paste/views.py
+++ b/saic/paste/views.py
@@ -751,13 +751,13 @@ def paste_embed(request, pk, private_key=None):
             paste.revision.parent_set.private_key != private_key):
         raise Http404
     if jsonp:
-        data = render_to_string('embed.js', {'paste': paste, 'theme': theme},
+        data = render_to_string('embed.html', {'paste': paste, 'theme': theme},
                                 RequestContext(request))
         call = '%s(%s);' % (jsonp, json.dumps({'embed': data, 'args': args}));
-        return HttpResponse(call, mimetype='text/javascript');
-    return render_to_response('embed.js',
+        return HttpResponse(call, mimetype='text/html');
+    return render_to_response('embed.html',
             {'paste': paste, 'theme': theme, 'jsonp': jsonp, 'args': args}, 
-            RequestContext(request), mimetype='text/javascript');
+            RequestContext(request), mimetype='text/html');
 
 def live_paste(request):
     commit_kwargs = {}


### PR DESCRIPTION
When I tried to deploy f55d4 I found that for embedded links (labeled embed on each paste), views.py attempts to render_to_string 'embed.js', but embed.js doesn't exist in the repository.

Attempts to click the embed link returned a TemplateDoesNotExist exception.

I am not sure if there used to be an embed.js or if there is supposed to be an embed.js, but if instead I pointed everything at embed.html (and change the mimetype to match), things started working and the embed view properly rendered.
