### PR TITLE
Use a fixed-width font fallback for the paste view <pre>

### DIFF
--- a/saic/paste/static/css/view.css
+++ b/saic/paste/static/css/view.css
@@ -52,7 +52,7 @@ div.paste > div {
 
 pre {
     overflow: auto;
-    font-family: 'Droid Sans Mono', sans-serif;
+    font-family: 'Droid Sans Mono', Monaco, Menlo, Consolas, "Courier New", monospace;
     font-size: 0.75em;
     line-height: 1.5em;
 }


### PR DESCRIPTION
It seems like [this change](https://github.com/justinvh/gitpaste/commit/086b10e4dcbccda30b8d4ba942d1c2dc71dc3762#diff-bb46b4ac91313e974011145488cab820L50) made the `<pre>` field in the paste display proportional on machines that don't have Droid Sans Mono installed (for example, all macs out of the box). This change alters the fallback to be "monospace", and adds a bunch of fixed-width fonts that are somewhat pleasing to look at.
